### PR TITLE
Avoids executing inject.js twice

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,11 +14,6 @@
     "default_icon": "icons/default-64.png",
     "default_title": "Click on any element to get the xPath"
   },
-  "content_scripts": [{ 
-    "all_frames": true,
-    "matches": ["<all_urls>"],
-    "js":["inspect.js"]
-  }],
   "options_ui": {
     "page": "options.html"
   },


### PR DESCRIPTION
Removed the `inspect.js` from `manifest.json` as it was already injected using `background.js`